### PR TITLE
Inkscape uses absolute paths in svg->pdf.

### DIFF
--- a/bin/buildfigpdfs
+++ b/bin/buildfigpdfs
@@ -16,6 +16,7 @@ else
 fi
 }
 
+currdir=`pwd`
 for svgfile in "$@"
 do
 	pdffile="${svgfile/svg/pdf}"
@@ -24,6 +25,6 @@ do
 	if [ ! -f $pdffile ] || [ ${srcdate} -ge ${destdate} ];
 	then
 	echo "Detected change in $svgfile"
-	inkscape --export-pdf $pdffile $svgfile
+	inkscape --export-pdf ${currdir}/$pdffile ${currdir}/$svgfile
 fi
 done


### PR DESCRIPTION
A known limitation of X11 in MacOSX results in a bug where Inkscape
fails when converting from SVG to PDF. For details of the bug itself,
see https://bugs.launchpad.net/inkscape/+bug/1449251. A fix is to use
absolute paths when specifying input and output files to Inkscape which
is implemented in the file bin/buildfigpdfs.