### PR TITLE
Handle spaces in directory names for buildfigpdfs.

### DIFF
--- a/bin/buildfigpdfs
+++ b/bin/buildfigpdfs
@@ -16,7 +16,7 @@ else
 fi
 }
 
-currdir=`pwd`
+currdir="`pwd`"
 for svgfile in "$@"
 do
 	pdffile="${svgfile/svg/pdf}"
@@ -25,6 +25,6 @@ do
 	if [ ! -f $pdffile ] || [ ${srcdate} -ge ${destdate} ];
 	then
 	echo "Detected change in $svgfile"
-	inkscape --export-pdf ${currdir}/$pdffile ${currdir}/$svgfile
+	inkscape --export-pdf "${currdir}/$pdffile" "${currdir}/$svgfile"
 fi
 done


### PR DESCRIPTION
The changes now allow spaces in the directory names to be handled
appropriately.